### PR TITLE
fix: allow using --force to push history changes to the backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Github to AWS CodeCommit Sync
-description: 'Synchronize from GitHub to CodeCommit via GitHub Actions using IAM credentials.'
-author: 'DamianBis'
+description: "Synchronize from GitHub to CodeCommit via GitHub Actions using IAM credentials."
+author: "Equiem"
 branding:
   icon: terminal
   color: yellow
@@ -12,5 +12,5 @@ inputs:
     description: Region of the CodeCommit repository. - defaults to us-east-1
     required: false
 runs:
-  using: 'docker'
-  image: './Dockerfile'
+  using: "docker"
+  image: "./Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,4 @@ if [[ $(git lfs ls-files) ]]; then
   git lfs uninstall
 fi
 
-git push --set-upstream ${remote} $(git rev-parse --abbrev-ref HEAD)
+git push --force --set-upstream ${remote} $(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
## What was done

Use `--force` to push history changes to the backup.

## Why

Ideally this doesn't happen, but if it does this is better than breaking the backup forever.